### PR TITLE
feat: add OpenAI-compatible API provider option

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -15,6 +15,8 @@ MAX_MESSAGE_LENGTH=4000
 OPENROUTER_MAX_TOKENS=800
 # Custom OpenRouter API URL (leave empty for default)
 OPENROUTER_API_URL=
+# API key for OpenRouter
+OPENROUTER_API_KEY=
 # Default OpenRouter model (leave empty to select manually)
 OPENROUTER_DEFAULT_MODEL=
 # Temperature for OpenRouter responses (0.0 to 1.0)

--- a/.env-dist
+++ b/.env-dist
@@ -1,29 +1,39 @@
-# Configuration du cache
-# Taille maximale du cache en Mo
+# Cache Configuration
+# Maximum cache size in megabytes
 CACHE_MAX_SIZE_MB=100
-# Durée maximale de conservation des entrées du cache en jours
+# Maximum number of days to keep cache entries
 CACHE_MAX_AGE_DAYS=30
-# Nombre maximum d'entrées dans le cache
+# Maximum number of entries in the cache
 CACHE_MAX_ENTRIES=1000
 
-# Configuration des messages
-# Taille maximale d'un message (en caractères) avant troncature
+# Message Configuration
+# Maximum message length (in characters) before truncating
 MAX_MESSAGE_LENGTH=4000
 
-# Configuration OpenRouter
-# Nombre maximum de tokens pour les réponses OpenRouter
+# OpenRouter Configuration
+# Maximum tokens for OpenRouter responses
 OPENROUTER_MAX_TOKENS=800
-# URL de l'API OpenRouter (laisser vide pour utiliser la valeur par défaut)
+# Custom OpenRouter API URL (leave empty for default)
 OPENROUTER_API_URL=
-# Modèle OpenRouter par défaut (laisser vide pour sélectionner manuellement)
+# Default OpenRouter model (leave empty to select manually)
 OPENROUTER_DEFAULT_MODEL=
-# Température pour les requêtes OpenRouter (0.0 à 1.0)
+# Temperature for OpenRouter responses (0.0 to 1.0)
 OPENROUTER_TEMPERATURE=0.3
 
-# Configuration Ollama
-# URL de l'API Ollama (laisser vide pour utiliser la valeur par défaut)
+# Ollama Configuration
+# Custom Ollama API URL (leave empty for default)
 OLLAMA_API_URL=
-# Modèle Ollama par défaut (laisser vide pour sélectionner manuellement)
+# Default Ollama model (leave empty to select manually)
 OLLAMA_DEFAULT_MODEL=
-# Température pour les requêtes Ollama (0.0 à 1.0)
+# Temperature for Ollama responses (0.0 to 1.0)
 OLLAMA_TEMPERATURE=0.3
+
+# OpenAI-compatible Configuration
+# Custom OpenAI-compatible API URL (e.g., https://api.openai.com/v1/chat/completions)
+OPENAI_API_URL=
+# API key for OpenAI-compatible API
+OPENAI_API_KEY=
+# Default model name (e.g., gpt-4, claude-3-opus, etc.)
+OPENAI_DEFAULT_MODEL=
+# Temperature for OpenAI-compatible responses (0.0 to 1.0)
+OPENAI_TEMPERATURE=0.3

--- a/.env-dist
+++ b/.env-dist
@@ -13,29 +13,30 @@ MAX_MESSAGE_LENGTH=4000
 # OpenRouter Configuration
 # Maximum tokens for OpenRouter responses
 OPENROUTER_MAX_TOKENS=800
-# Custom OpenRouter API URL (leave empty for default)
-OPENROUTER_API_URL=
+# Custom OpenRouter API URL (use "" for default)
+OPENROUTER_API_URL=""
 # API key for OpenRouter
-OPENROUTER_API_KEY=
-# Default OpenRouter model (leave empty to select manually)
-OPENROUTER_DEFAULT_MODEL=
+OPENROUTER_API_KEY=""
+# Default OpenRouter model (use "" to select manually)
+OPENROUTER_DEFAULT_MODEL=""
 # Temperature for OpenRouter responses (0.0 to 1.0)
 OPENROUTER_TEMPERATURE=0.3
 
 # Ollama Configuration
-# Custom Ollama API URL (leave empty for default)
-OLLAMA_API_URL=
-# Default Ollama model (leave empty to select manually)
-OLLAMA_DEFAULT_MODEL=
+# Custom Ollama API URL (use "" for default)
+OLLAMA_API_URL=""
+# Default Ollama model (use "" to select manually)
+OLLAMA_DEFAULT_MODEL=""
 # Temperature for Ollama responses (0.0 to 1.0)
 OLLAMA_TEMPERATURE=0.3
 
 # OpenAI-compatible Configuration
 # Custom OpenAI-compatible API URL (e.g., https://api.openai.com/v1/chat/completions)
-OPENAI_API_URL=
+OPENAI_API_URL=""
 # API key for OpenAI-compatible API
-OPENAI_API_KEY=
+OPENAI_API_KEY=""
 # Default model name (e.g., gpt-4, claude-3-opus, etc.)
-OPENAI_DEFAULT_MODEL=
+OPENAI_DEFAULT_MODEL=""
 # Temperature for OpenAI-compatible responses (0.0 to 1.0)
 OPENAI_TEMPERATURE=0.3
+

--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@
 
 - Analyze HTTP requests for security issues with "AI Suggest" tab
 - Understand HTTP responses with the "AI Explain" tab
-- Support for multiple AI providers (OpenRouter or local Ollama)
+- Support for multiple AI providers:
+  - **OpenRouter** - Access to Claude, GPT-4, and many other models
+  - **Ollama** - Run models locally without API keys
+  - **OpenAI-compatible** - Use any OpenAI-compatible API (OpenAI, Groq, z.ai GLM, DeepSeek, etc.)
 - Caching system to avoid repeated analysis of identical requests
 - Configurable prompt templates
-- API Key management
+- Streaming responses with real-time feedback
+- Support for reasoning models (GLM, DeepSeek-R1)
 
 ![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/aqua.png)
 
@@ -30,7 +34,7 @@
 
 ## ⚙️ Configuration
 
-The extension supports two AI providers:
+The extension supports three AI providers:
 
 ### OpenRouter
 - Requires an API key (get one from [openrouter.ai](https://openrouter.ai))
@@ -43,6 +47,16 @@ The extension supports two AI providers:
 - Run models locally with no API keys needed
 - Enter your Ollama URL (default: http://localhost:11434/api/generate)
 - Click "Fetch Models" to see available models on your Ollama server
+
+### OpenAI-compatible
+- Use any OpenAI-compatible API endpoint
+- Supports: OpenAI, Groq, z.ai GLM, DeepSeek, Together AI, etc.
+- Configure:
+  - **API URL**: The endpoint URL (e.g., `https://api.openai.com/v1/chat/completions`)
+  - **API Key**: Your API key for the service
+  - **Model Name**: The model to use (e.g., `gpt-4`, `claude-3-opus-20240229`, `glm-4`)
+- No "Fetch Models" button - enter the model name manually
+- Supports reasoning models like GLM and DeepSeek-R1 (only shows final answer, not reasoning)
 
 ### 🔧 Environment Variables (.env)
 
@@ -73,6 +87,12 @@ OPENROUTER_TEMPERATURE=0.3 # Temperature for response generation (0.0-1.0)
 OLLAMA_API_URL=            # Custom API URL (leave empty for default)
 OLLAMA_DEFAULT_MODEL=      # Default model to use (leave empty to select manually)
 OLLAMA_TEMPERATURE=0.3     # Temperature for response generation (0.0-1.0)
+
+# OpenAI-compatible configuration
+OPENAI_API_URL=            # Custom API URL (e.g., https://api.openai.com/v1/chat/completions)
+OPENAI_API_KEY=            # API key for the service
+OPENAI_DEFAULT_MODEL=      # Default model to use (e.g., gpt-4, claude-3-opus-20240229)
+OPENAI_TEMPERATURE=0.3     # Temperature for response generation (0.0-1.0)
 ```
 
 ![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/aqua.png)
@@ -136,7 +156,7 @@ The project is organized into the following modules:
 
 - **main.py**: Main extension entry point
 - **core/**: Core functionality
-  - **api_handlers.py**: API communication with OpenRouter and Ollama
+  - **api_handlers.py**: API communication with OpenRouter, Ollama, and OpenAI-compatible APIs
   - **cache.py**: Caching system with performance optimizations
   - **config_loader.py**: Configuration and .env file handling
   - **models.py**: Model management

--- a/README.md
+++ b/README.md
@@ -41,17 +41,19 @@ The extension supports three AI providers:
 - Supports a wide range of powerful models like Claude, GPT, etc.
 - Select a model from the list after fetching available models
 - For best results, prefer "instruct" models
+- Can be configured via UI or `.env` file (`OPENROUTER_API_KEY`, `OPENROUTER_DEFAULT_MODEL`)
 
 ### Ollama
 - Requires a local Ollama installation (get from [ollama.ai](https://ollama.ai))
 - Run models locally with no API keys needed
 - Enter your Ollama URL (default: http://localhost:11434/api/generate)
 - Click "Fetch Models" to see available models on your Ollama server
+- Can be configured via UI or `.env` file (`OLLAMA_API_URL`, `OLLAMA_DEFAULT_MODEL`)
 
 ### OpenAI-compatible
 - Use any OpenAI-compatible API endpoint
 - Supports: OpenAI, Groq, z.ai GLM, DeepSeek, Together AI, etc.
-- Configure:
+- Configure in UI or via `.env` file:
   - **API URL**: The endpoint URL (e.g., `https://api.openai.com/v1/chat/completions`)
   - **API Key**: Your API key for the service
   - **Model Name**: The model to use (e.g., `gpt-4`, `claude-3-opus-20240229`, `glm-4`)
@@ -60,11 +62,14 @@ The extension supports three AI providers:
 
 ### 🔧 Environment Variables (.env)
 
-The extension works with default values without any custom configuration. However, if you want to customize its behavior:
+The extension can be configured via environment variables using a `.env` file:
 
-1. A template file `.env-dist` is provided instead
-2. Copy or rename `.env-dist` to `.env` to start using custom settings
-3. Edit the `.env` file to change settings according to your needs
+1. Copy `.env-dist` to `.env` to start using environment variables
+2. Edit the `.env` file with your API keys and preferences
+3. Environment variables are used as **defaults** when Burp settings are empty
+4. Once loaded from `.env`, values are saved to Burp settings for persistence
+
+**Note**: You can also configure everything through the Burp Suite UI without using `.env` files.
 
 If no `.env` file is found, the extension will use these default values:
 
@@ -80,6 +85,7 @@ MAX_MESSAGE_LENGTH=4000    # Maximum length before truncating HTTP messages
 # OpenRouter configuration
 OPENROUTER_MAX_TOKENS=800  # Maximum tokens for OpenRouter responses
 OPENROUTER_API_URL=        # Custom API URL (leave empty for default)
+OPENROUTER_API_KEY=         # API key for OpenRouter
 OPENROUTER_DEFAULT_MODEL=  # Default model to use (leave empty to select manually)
 OPENROUTER_TEMPERATURE=0.3 # Temperature for response generation (0.0-1.0)
 

--- a/core/cache.py
+++ b/core/cache.py
@@ -43,7 +43,6 @@ class AnalysisCache:
             if extensionsDir:
                 parentDir = os.path.dirname(extensionsDir)
                 self._cachePath = os.path.join(parentDir, "ai_analyzer_cache.json")
-                self._stdout.write("Cache location: " + self._cachePath + "\n")
 
                 # Load cache if it exists
                 if os.path.exists(self._cachePath):
@@ -52,7 +51,7 @@ class AnalysisCache:
                             cacheData = json.load(f)
                             self._analyzeCache = cacheData.get("cache", {})
                             self._cacheMetadata = cacheData.get("metadata", {})
-                            
+
                             # Add timestamps for entries without metadata (backward compatibility)
                             for key in self._analyzeCache:
                                 if key not in self._cacheMetadata:
@@ -64,9 +63,7 @@ class AnalysisCache:
                             # Recalculate statistics
                             self._cacheStats["entries"] = len(self._analyzeCache)
                             self._cacheStats["size"] = sum(meta.get("size", 0) for meta in self._cacheMetadata.values())
-                            self._stdout.write("Cache loaded from file: {0} entries, {1} bytes\n".format(
-                                self._cacheStats["entries"], self._cacheStats["size"]))
-                            
+
                             # Clean up cache based on age and size limits
                             self._clean_cache()
                     except Exception as e:

--- a/core/config_loader.py
+++ b/core/config_loader.py
@@ -55,10 +55,8 @@ class ConfigLoader:
                 if os.path.exists(self._env_path):
                     self._load_env_file()
                 else:
-                    self._stdout.write("No .env file found, using default values\n")
                     self._config = self._defaults.copy()
             else:
-                self._stdout.write("Could not determine extension path, using default values\n")
                 self._config = self._defaults.copy()
         except Exception as e:
             self._stdout.write("Error loading config: " + str(e) + "\n")
@@ -98,8 +96,7 @@ class ConfigLoader:
                 except Exception:
                     # Use the string value if conversion fails
                     self._config[key] = value
-            
-            self._stdout.write("Config loaded from .env file\n")
+
         except Exception as e:
             self._stdout.write("Error parsing .env file: " + str(e) + "\n")
             self._config = self._defaults.copy()

--- a/core/config_loader.py
+++ b/core/config_loader.py
@@ -26,20 +26,26 @@ class ConfigLoader:
             "CACHE_MAX_SIZE_MB": 100,
             "CACHE_MAX_AGE_DAYS": 30,
             "CACHE_MAX_ENTRIES": 1000,
-            
+
             # Message settings
             "MAX_MESSAGE_LENGTH": 4000,
-            
+
             # OpenRouter settings
             "OPENROUTER_MAX_TOKENS": 800,
             "OPENROUTER_API_URL": "https://openrouter.ai/api/v1/chat/completions",
             "OPENROUTER_DEFAULT_MODEL": "",
             "OPENROUTER_TEMPERATURE": 0.3,
-            
+
             # Ollama settings
             "OLLAMA_API_URL": "http://localhost:11434/api/generate",
             "OLLAMA_DEFAULT_MODEL": "",
-            "OLLAMA_TEMPERATURE": 0.3
+            "OLLAMA_TEMPERATURE": 0.3,
+
+            # OpenAI-compatible settings
+            "OPENAI_API_URL": "",
+            "OPENAI_API_KEY": "",
+            "OPENAI_DEFAULT_MODEL": "",
+            "OPENAI_TEMPERATURE": 0.3
         }
         
         # Try to load .env file

--- a/core/config_loader.py
+++ b/core/config_loader.py
@@ -33,6 +33,7 @@ class ConfigLoader:
             # OpenRouter settings
             "OPENROUTER_MAX_TOKENS": 800,
             "OPENROUTER_API_URL": "https://openrouter.ai/api/v1/chat/completions",
+            "OPENROUTER_API_KEY": "",
             "OPENROUTER_DEFAULT_MODEL": "",
             "OPENROUTER_TEMPERATURE": 0.3,
 

--- a/core/models.py
+++ b/core/models.py
@@ -2,56 +2,70 @@
 
 class ModelManager:
     """
-    Manages AI model selection and availability for both OpenRouter and Ollama.
+    Manages AI model selection and availability for OpenRouter, Ollama, and OpenAI-compatible providers.
     """
 
     def __init__(self):
         """Initialize the model manager with empty model lists"""
         self._available_models = []  # OpenRouter models
         self._available_ollama_models = []  # Ollama models
+        self._available_openai_models = []  # OpenAI-compatible models
 
-    def get_available_models(self, use_ollama=False):
+    def get_available_models(self, use_ollama=False, use_openai=False):
         """
         Get the list of available models.
-        
+
         Args:
-            use_ollama: Whether to get Ollama models (True) or OpenRouter models (False)
-            
+            use_ollama: Whether to get Ollama models
+            use_openai: Whether to get OpenAI-compatible models
+
         Returns:
             List of available model names
         """
+        if use_openai:
+            return self._available_openai_models
         return self._available_ollama_models if use_ollama else self._available_models
 
-    def add_available_model(self, model, use_ollama=False):
+    def add_available_model(self, model, use_ollama=False, use_openai=False):
         """
         Add a model to the available models list.
-        
+
         Args:
             model: Model name to add
-            use_ollama: Whether to add to Ollama models (True) or OpenRouter models (False)
-            
+            use_ollama: Whether to add to Ollama models
+            use_openai: Whether to add to OpenAI-compatible models
+
         Returns:
             True if model was added, False if it was already in the list
         """
-        model_list = self._available_ollama_models if use_ollama else self._available_models
+        if use_openai:
+            model_list = self._available_openai_models
+        elif use_ollama:
+            model_list = self._available_ollama_models
+        else:
+            model_list = self._available_models
+
         if model not in model_list:
             model_list.append(model)
             return True
         return False
 
-    def set_available_models(self, models, use_ollama=False):
+    def set_available_models(self, models, use_ollama=False, use_openai=False):
         """
         Set the complete list of available models.
-        
+
         Args:
             models: List of model names
-            use_ollama: Whether to set Ollama models (True) or OpenRouter models (False)
+            use_ollama: Whether to set Ollama models
+            use_openai: Whether to set OpenAI-compatible models
         """
         # Always sort models alphabetically
         if models:
             models.sort()
 
-        if use_ollama:
+        if use_openai:
+            self._available_openai_models = models
+        elif use_ollama:
             self._available_ollama_models = models
         else:
             self._available_models = models

--- a/main.py
+++ b/main.py
@@ -47,21 +47,15 @@ class BurpExtender(IBurpExtender, IMessageEditorTabFactory, ITab):
         saved_use_openai = callbacks.loadExtensionSetting("ai_analyzer_use_openai") == "true"
         
         # Verification and correction: ensure active model matches provider
-        if saved_use_ollama:
-            saved_model = saved_ollama_model or ""
-            # Ensure active model is Ollama model
+        if saved_use_openai:
+            saved_model = saved_openai_model or ""
             callbacks.saveExtensionSetting("ai_analyzer_model", saved_model)
-            stdout.write("Using Ollama mode with model: " + saved_model + "\n")
+        elif saved_use_ollama:
+            saved_model = saved_ollama_model or ""
+            callbacks.saveExtensionSetting("ai_analyzer_model", saved_model)
         else:
             saved_model = saved_openrouter_model or ""
-            # Ensure active model is OpenRouter model
             callbacks.saveExtensionSetting("ai_analyzer_model", saved_model)
-
-        # Log loaded settings for debugging (only if models are defined)
-        if saved_ollama_model:
-            stdout.write("Loaded settings - Ollama model: " + saved_ollama_model + "\n")
-        if saved_openrouter_model:
-            stdout.write("Loaded settings - OpenRouter model: " + saved_openrouter_model + "\n")
 
         # Default configuration
         self._config = {

--- a/prompts/explain_prompt.txt
+++ b/prompts/explain_prompt.txt
@@ -7,7 +7,7 @@ Your role is to analyze an HTTP response received during web application securit
 - Suggest interesting elements or patterns in the response that might be worth deeper inspection (e.g., verbose errors, stack traces, misconfigured headers, CORS policies, caching, etc.).
 - From a security perspective, list things to examine further or that may indicate possible misconfigurations or vulnerabilities.
 
-For JavaScript files (.js, .jsx, angular) in the response:
+For JavaScript files (.js, .jsx, Angular) in the response:
    Look for: API endpoints, hardcoded secrets/keys, functions handling sensitive user input
 
 Format your answer as a bulleted list by importance and relevance priority to help prioritize tests.

--- a/prompts/explain_prompt.txt
+++ b/prompts/explain_prompt.txt
@@ -7,6 +7,9 @@ Your role is to analyze an HTTP response received during web application securit
 - Suggest interesting elements or patterns in the response that might be worth deeper inspection (e.g., verbose errors, stack traces, misconfigured headers, CORS policies, caching, etc.).
 - From a security perspective, list things to examine further or that may indicate possible misconfigurations or vulnerabilities.
 
+For JavaScript files (.js, .jsx, angular) in the response:
+   Look for: API endpoints, hardcoded secrets/keys, functions handling sensitive user input
+
 Format your answer as a bulleted list by importance and relevance priority to help prioritize tests.
 
 Keep sentences concise (max ~150 characters per line).

--- a/ui/analyzer_tabs.py
+++ b/ui/analyzer_tabs.py
@@ -244,16 +244,34 @@ class BaseAnalyzerTab(IMessageEditorTab, IMessageEditorController):
                 # Use the right API manager for your configuration
                 config = self._extender.get_config()
                 use_ollama = config.get("use_ollama", False)
-                
+                use_openai = config.get("use_openai", False)
+
                 # Check configuration before continuing
-                if use_ollama:
+                if use_openai:
+                    # Checks for OpenAI-compatible
+                    openai_api_url = config.get("openai_api_url", "")
+                    openai_api_key = config.get("openai_api_key", "")
+                    openai_model = config.get("openai_model", "")
+
+                    if not openai_api_url or openai_api_url.strip() == "":
+                        self._update_text_safely("Error: OpenAI-compatible API URL not configured. Please enter the URL in the AI Request Analyzer tab.")
+                        return
+
+                    if not openai_api_key or openai_api_key.strip() == "":
+                        self._update_text_safely("Error: OpenAI-compatible API key not configured. Please enter your API key in the AI Request Analyzer tab.")
+                        return
+
+                    if not openai_model or openai_model.strip() == "":
+                        self._update_text_safely("Error: OpenAI-compatible model not configured. Please enter the model name in the AI Request Analyzer tab.")
+                        return
+                elif use_ollama:
                     model = config.get("model", "")
                     ollama_url = config.get("ollama_url", "")
-                    
+
                     if not model or model == "Type your model name or fetch the list of available model":
                         self._update_text_safely("Error: No Ollama model selected. Please configure a model in the AI Request Analyzer tab.")
                         return
-                    
+
                     if not ollama_url:
                         self._update_text_safely("Error: Ollama URL not configured. Please enter the Ollama URL in the AI Request Analyzer tab.")
                         return
@@ -261,17 +279,17 @@ class BaseAnalyzerTab(IMessageEditorTab, IMessageEditorController):
                     # Checks for OpenRouter
                     api_key = config.get("api_key", "")
                     model = config.get("model", "")
-                    
+
                     if not api_key or api_key == "Enter your API Key here...":
                         self._update_text_safely("Error: OpenRouter API key not configured. Please enter your API key in the AI Request Analyzer tab.")
                         return
-                    
+
                     if not model or model == "Type your model name or fetch the list of available model":
                         self._update_text_safely("Error: OpenRouter model not selected. Please choose a model in the AI Request Analyzer tab.")
                         return
-                
+
                 # Get the API manager for the current mode
-                api_handler = self._extender.get_api_handler(use_ollama)
+                api_handler = self._extender.get_api_handler(use_ollama, use_openai)
                 
                 # Analyze the message
                 result = api_handler.analyze_message(

--- a/ui/analyzer_tabs.py
+++ b/ui/analyzer_tabs.py
@@ -140,7 +140,6 @@ class BaseAnalyzerTab(IMessageEditorTab, IMessageEditorController):
             # Check if we already have a cached analysis
             cached_result = self._extender.get_cached_analysis(new_hash, is_request)
             if cached_result:
-                self._stdout.write("Found cached analysis for message hash: {0}\n".format(new_hash))
                 # Convert cached text to bytes
                 cached_bytes = self._extender._helpers.stringToBytes(cached_result)
                 self._text_editor.setText(cached_bytes)
@@ -173,11 +172,7 @@ class BaseAnalyzerTab(IMessageEditorTab, IMessageEditorController):
         thread = threading.Thread(target=self._perform_analysis)
         thread.daemon = True
         thread.start()
-        
-        # Log the analysis request
-        if self._current_message:
-            self._stdout.write("Analysis request started for message hash: {0}\n".format(self._current_message_hash))
-    
+
     # Update UI safely
     def _update_text_safely(self, text):
         """

--- a/ui/config_tab.py
+++ b/ui/config_tab.py
@@ -134,8 +134,8 @@ class ConfigTab:
         radio_center_panel = JPanel()
         radio_center_panel.setLayout(GridLayout(1, 3, 20, 0))
         radio_center_panel.setAlignmentX(Component.CENTER_ALIGNMENT)
-        radio_center_panel.setMaximumSize(Dimension(550, 30))
-        radio_center_panel.setPreferredSize(Dimension(550, 30))
+        radio_center_panel.setMaximumSize(Dimension(700, 30))
+        radio_center_panel.setPreferredSize(Dimension(700, 30))
         if burp_background:
             radio_center_panel.setBackground(burp_background)
         
@@ -145,18 +145,27 @@ class ConfigTab:
         # Create OpenRouter radio
         self._openrouter_radio = JRadioButton("OpenRouter", not self._extender.get_config()["use_ollama"] and not self._extender.get_config().get("use_openai", False))
         self._openrouter_radio.setHorizontalAlignment(JRadioButton.CENTER)
+        self._openrouter_radio.setPreferredSize(Dimension(120, 25))
+        self._openrouter_radio.setMaximumSize(Dimension(120, 25))
+        self._openrouter_radio.setMinimumSize(Dimension(120, 25))
         self._openrouter_radio.addActionListener(ApiSelectionListener(self._extender, False, False))
         api_button_group.add(self._openrouter_radio)
-        
+
         # Create Ollama radio
         self._ollama_radio = JRadioButton("Ollama", self._extender.get_config()["use_ollama"])
         self._ollama_radio.setHorizontalAlignment(JRadioButton.CENTER)
+        self._ollama_radio.setPreferredSize(Dimension(100, 25))
+        self._ollama_radio.setMaximumSize(Dimension(100, 25))
+        self._ollama_radio.setMinimumSize(Dimension(100, 25))
         self._ollama_radio.addActionListener(ApiSelectionListener(self._extender, True, False))
         api_button_group.add(self._ollama_radio)
 
         # Create OpenAI-compatible radio
         self._openai_radio = JRadioButton("OpenAI-compatible", self._extender.get_config().get("use_openai", False))
         self._openai_radio.setHorizontalAlignment(JRadioButton.CENTER)
+        self._openai_radio.setPreferredSize(Dimension(140, 25))
+        self._openai_radio.setMaximumSize(Dimension(140, 25))
+        self._openai_radio.setMinimumSize(Dimension(140, 25))
         self._openai_radio.addActionListener(ApiSelectionListener(self._extender, False, True))
         api_button_group.add(self._openai_radio)
 
@@ -170,7 +179,7 @@ class ConfigTab:
         
         # Add to left panel, centered
         radio_panel.setAlignmentX(Component.CENTER_ALIGNMENT)
-        radio_panel.setMaximumSize(Dimension(400, 30))
+        radio_panel.setMaximumSize(Dimension(500, 30))
         left_panel.add(Box.createVerticalStrut(10))
         left_panel.add(radio_panel)
         left_panel.add(Box.createVerticalStrut(20))

--- a/ui/config_tab.py
+++ b/ui/config_tab.py
@@ -14,6 +14,18 @@ from utils.listeners import FetchModelsListener, FetchOllamaModelsListener
 from utils.listeners import TogglePasswordVisibilityListener, ToggleOllamaUrlVisibilityListener
 from utils.listeners import ToggleOpenAIUrlVisibilityListener, ToggleOpenAIKeyVisibilityListener
 
+# Shared constants for placeholders and dimensions
+MODEL_PLACEHOLDER = "Type your model name or fetch the list of available model"
+API_KEY_PLACEHOLDER = "Enter your API Key here..."
+OPENAI_URL_PLACEHOLDER = "https://api.openai.com/v1/chat/completions"
+OPENAI_MODEL_PLACEHOLDER = "Enter your model name (e.g., gpt-4)"
+OLLAMA_URL_DEFAULT = "http://localhost:11434/api/generate"
+
+FIELD_DIM = Dimension(530, 25)
+ROW_DIM = Dimension(600, 30)
+EYE_BUTTON_DIM = Dimension(40, 25)
+
+
 class ConfigTab:
     """
     Configuration tab for the extension.
@@ -1298,3 +1310,36 @@ class ConfigTab:
             # Add a new listener with a complete list of models
             editor_component_ol.addKeyListener(
                 FilterKeyListener(self._ollama_model_combo, self._extender.get_available_models(True)))
+
+    def toggle_secret_field(self, field, button, hidden_attr_name, actual_value, placeholder):
+        """
+        Generic helper for toggling visibility of sensitive fields (URLs, API keys).
+
+        Args:
+            field: The JTextField to update
+            button: The JButton to update text on
+            hidden_attr_name: The attribute name for the hidden state (e.g., "_is_api_key_hidden")
+            actual_value: The actual value to show/hide
+            placeholder: The placeholder text to ignore
+        """
+        if not hasattr(self, hidden_attr_name):
+            return
+
+        hidden = not getattr(self, hidden_attr_name)
+        setattr(self, hidden_attr_name, hidden)
+
+        if not actual_value or actual_value == placeholder:
+            button.setText("View" if hidden else "Hide")
+            return
+
+        if hidden:
+            field.setText('*' * len(actual_value))
+            button.setText("View")
+        else:
+            field.setText(actual_value)
+            button.setText("Hide")
+
+        field.revalidate()
+        field.repaint()
+        button.revalidate()
+        button.repaint()

--- a/ui/config_tab.py
+++ b/ui/config_tab.py
@@ -579,7 +579,7 @@ class ConfigTab:
 
         # URL field with border
         saved_openai_url = self._extender.get_config().get("openai_api_url", "")
-        openai_url_placeholder = "https://api.openai.com/v1/chat/completions"
+        openai_url_placeholder = "Enter OpenAI API URL here..."
         self._openai_url_field = JTextField(saved_openai_url or openai_url_placeholder, 60)
         self._openai_url_field.setBorder(BorderFactory.createCompoundBorder(
             BorderFactory.createLineBorder(Color.GRAY),
@@ -616,8 +616,7 @@ class ConfigTab:
         self._toggle_openai_url_button.addActionListener(ToggleOpenAIUrlVisibilityListener(self))
 
         # Initially mask the OpenAI URL if it's not empty and not a placeholder
-        openai_url_placeholder = "https://api.openai.com/v1/chat/completions"
-        if saved_openai_url and saved_openai_url != openai_url_placeholder:
+        if saved_openai_url:
             masked_url = '*' * len(saved_openai_url)
             self._openai_url_field.setText(masked_url)
 
@@ -1140,9 +1139,9 @@ class ConfigTab:
 
                     # Update OpenAI URL field with saved value
                     openai_url = self._extender.get_config().get("openai_api_url", "")
-                    openai_url_placeholder = "https://api.openai.com/v1/chat/completions"
+                    openai_url_placeholder = "Enter OpenAI API URL here..."
                     if hasattr(self, "_openai_url_field"):
-                        if openai_url and openai_url != openai_url_placeholder:
+                        if openai_url:
                             # URL is configured, show it (masked if hidden)
                             if self._is_openai_url_hidden:
                                 self._openai_url_field.setText('*' * len(openai_url))
@@ -1153,16 +1152,15 @@ class ConfigTab:
 
                     # Update OpenAI API key field with saved value
                     openai_key = self._extender.get_config().get("openai_api_key", "")
-                    openai_key_placeholder = "Enter your API Key here..."
                     if hasattr(self, "_openai_api_key_field"):
-                        if openai_key and openai_key != openai_key_placeholder:
+                        if openai_key:
                             # Key is configured, show it (masked if hidden)
                             if self._is_openai_api_key_hidden:
                                 self._openai_api_key_field.setText('*' * len(openai_key))
                             else:
                                 self._openai_api_key_field.setText(openai_key)
                         else:
-                            self._openai_api_key_field.setText(openai_key_placeholder)
+                            self._openai_api_key_field.setText("Enter your API Key here...")
 
                 elif use_ollama:
                     # Reset OpenRouter ComboBox

--- a/utils/listeners.py
+++ b/utils/listeners.py
@@ -442,7 +442,7 @@ class ApiSelectionListener(ActionListener):
 
                     # Update button text if button is provided
                     if self._button:
-                        self._button.setText("Hive" if self._use_ollama else "View")
+                        self._button.setText("Hide" if self._use_ollama else "View")
             except Exception as e:
                 stdout.write("Error updating UI after API selection: " + str(e) + "\n")
 

--- a/utils/listeners.py
+++ b/utils/listeners.py
@@ -518,11 +518,7 @@ class ClearCacheListener(ActionListener):
     def actionPerformed(self, event):
         # Clear the cache
         self._extender.clear_cache()
-        
-        # Log cache clearing
-        stdout = self._extender._callbacks.getStdout()
-        stdout.write("Analysis cache cleared!\n")
-        
+
         # Update cache statistics in UI
         if self._config_tab:
             self._config_tab.update_cache_stats()
@@ -638,9 +634,6 @@ class ClearSettingsListener(ActionListener):
             
             # Update UI
             config_tab.update_config_panels()
-            
-            # Log reset
-            self._extender._callbacks.getStdout().write("User settings have been reset!\n")
         except Exception as e:
             try:
                 self._extender._callbacks.getStdout().write("Error updating UI after settings reset: " + str(e) + "\n")

--- a/utils/listeners.py
+++ b/utils/listeners.py
@@ -451,79 +451,54 @@ class TogglePasswordVisibilityListener(ActionListener):
     """
     Listener for toggling API key visibility.
     """
-    
+
     def __init__(self, config_tab):
         """
         Initialize the listener.
-        
+
         Args:
             config_tab: The configuration tab
         """
         self._config_tab = config_tab
-    
+
     def actionPerformed(self, event):
-        # Toggle between "View" and "Hide"
-        current_button_text = self._config_tab._toggle_api_key_button.getText()
         actual_key = self._config_tab._extender.get_config()["api_key"]
-        
-        # Toggle state
-        self._config_tab._is_api_key_hidden = not self._config_tab._is_api_key_hidden
-        
-        # Update UI based on new state
-        if self._config_tab._is_api_key_hidden:
-            # If hiding, change to "View" and mask the key
-            self._config_tab._toggle_api_key_button.setText("View")
-            if actual_key and actual_key != "Enter your API Key here...":
-                self._config_tab._api_key_field.setText('*' * len(actual_key))
-        else:
-            # If showing, change to "Hide" and show the key
-            self._config_tab._toggle_api_key_button.setText("Hide")
-            if actual_key and actual_key != "Enter your API Key here...":
-                self._config_tab._api_key_field.setText(actual_key)
+        placeholder = "Enter your API Key here..."
+        self._config_tab.toggle_secret_field(
+            self._config_tab._api_key_field,
+            self._config_tab._toggle_api_key_button,
+            "_is_api_key_hidden",
+            actual_key,
+            placeholder,
+        )
 
 
 class ToggleOllamaUrlVisibilityListener(ActionListener):
     """
     Listener for toggling Ollama URL visibility.
     """
-    
+
     def __init__(self, config_tab):
         """
         Initialize the listener.
-        
+
         Args:
             config_tab: The configuration tab
         """
         self._config_tab = config_tab
-    
+
     def actionPerformed(self, event):
-        # Toggle visibility state
-        self._config_tab._is_ollama_url_hidden = not self._config_tab._is_ollama_url_hidden
-        
-        # Get the actual URL from config
         actual_url = self._config_tab._extender.get_config()["ollama_url"]
-        
-        # If no URL, do nothing
+        placeholder = ""
         if not actual_url:
             return
-        
-        # Update display based on state
-        if self._config_tab._is_ollama_url_hidden:
-            # Mask the URL
-            self._config_tab._ollama_url_field.setText('*' * len(actual_url))
-            # Update button text
-            self._config_tab._toggle_ollama_url_button.setText("View")
-        else:
-            # Show the URL
-            self._config_tab._ollama_url_field.setText(actual_url)
-            # Update button text
-            self._config_tab._toggle_ollama_url_button.setText("Hide")
-        
-        # Force UI update
-        self._config_tab._ollama_url_field.revalidate()
-        self._config_tab._ollama_url_field.repaint()
-        self._config_tab._toggle_ollama_url_button.revalidate()
-        self._config_tab._toggle_ollama_url_button.repaint()
+        self._config_tab.toggle_secret_field(
+            self._config_tab._ollama_url_field,
+            self._config_tab._toggle_ollama_url_button,
+            "_is_ollama_url_hidden",
+            actual_url,
+            placeholder,
+        )
 
 class ClearCacheListener(ActionListener):
     """
@@ -707,34 +682,17 @@ class ToggleOpenAIUrlVisibilityListener(ActionListener):
         self._config_tab = config_tab
 
     def actionPerformed(self, event):
-        # Toggle visibility state
-        self._config_tab._is_openai_url_hidden = not self._config_tab._is_openai_url_hidden
-
-        # Get the actual URL from config
         actual_url = self._config_tab._extender.get_config().get("openai_api_url", "")
         placeholder = "https://api.openai.com/v1/chat/completions"
-
-        # If no URL or placeholder, do nothing
         if not actual_url or actual_url == placeholder:
             return
-
-        # Update display based on state
-        if self._config_tab._is_openai_url_hidden:
-            # Mask the URL
-            self._config_tab._openai_url_field.setText('*' * len(actual_url))
-            # Update button text
-            self._config_tab._toggle_openai_url_button.setText("View")
-        else:
-            # Show the URL
-            self._config_tab._openai_url_field.setText(actual_url)
-            # Update button text
-            self._config_tab._toggle_openai_url_button.setText("Hide")
-
-        # Force UI update
-        self._config_tab._openai_url_field.revalidate()
-        self._config_tab._openai_url_field.repaint()
-        self._config_tab._toggle_openai_url_button.revalidate()
-        self._config_tab._toggle_openai_url_button.repaint()
+        self._config_tab.toggle_secret_field(
+            self._config_tab._openai_url_field,
+            self._config_tab._toggle_openai_url_button,
+            "_is_openai_url_hidden",
+            actual_url,
+            placeholder,
+        )
 
 
 class ToggleOpenAIKeyVisibilityListener(ActionListener):
@@ -752,22 +710,12 @@ class ToggleOpenAIKeyVisibilityListener(ActionListener):
         self._config_tab = config_tab
 
     def actionPerformed(self, event):
-        # Toggle state
-        current_button_text = self._config_tab._toggle_openai_api_key_button.getText()
         actual_key = self._config_tab._extender.get_config().get("openai_api_key", "")
         placeholder = "Enter your API Key here..."
-
-        # Toggle state
-        self._config_tab._is_openai_api_key_hidden = not self._config_tab._is_openai_api_key_hidden
-
-        # Update UI based on new state
-        if self._config_tab._is_openai_api_key_hidden:
-            # If hiding, change to "View" and mask the key
-            self._config_tab._toggle_openai_api_key_button.setText("View")
-            if actual_key and actual_key != placeholder:
-                self._config_tab._openai_api_key_field.setText('*' * len(actual_key))
-        else:
-            # If showing, change to "Hide" and show the key
-            self._config_tab._toggle_openai_api_key_button.setText("Hide")
-            if actual_key and actual_key != placeholder:
-                self._config_tab._openai_api_key_field.setText(actual_key)
+        self._config_tab.toggle_secret_field(
+            self._config_tab._openai_api_key_field,
+            self._config_tab._toggle_openai_api_key_button,
+            "_is_openai_api_key_hidden",
+            actual_key,
+            placeholder,
+        )


### PR DESCRIPTION
Fix:#1

## Summary

Add third API provider option "OpenAI-compatible" for connecting to any OpenAI-compatible API (such as z.ai GLM, OpenAI, Groq, etc.).

## Changes

- New radio button labeled "OpenAI-compatible" for provider selection
- Configuration fields: URL, API Key, and Model name (all with visibility toggles)
- OpenAI-compatible API format using standard `/chat/completions` endpoint
- Streaming support with automatic fallback to non-streaming mode
- Max tokens increased to 4000 (8000 for reasoning models like GLM/DeepSeek)
- Properly handles `reasoning_content` vs `content` fields for reasoning models
- Configuration persistence across provider switches (values are preserved)
- Special JS file analysis added to `explain_prompt.txt`

## Configuration Keys

| Key | Type | Description |
|-----|------|-------------|
| `openai_api_url` | string | Custom API endpoint URL |
| `openai_api_key` | string | Custom API authentication key |
| `openai_model` | string | Selected model name |
| `use_openai` | boolean | Provider selection flag |

## Verification

### Manual Testing Steps

1. **UI Verification**
   - Third radio button appears and is selectable
   - Selecting "OpenAI-compatible" shows configuration panel
   - URL, API key, and Model fields display correctly
   - Visibility toggles work for all three fields

2. **Configuration Persistence**
   - Enter values and restart Burp Suite → values are restored
   - Switch between providers → values are preserved correctly
   - "Clear Settings" resets OpenAI fields correctly

3. **Provider Switching**
   - Switch between OpenRouter, Ollama, and OpenAI-compatible
   - Each provider's model is saved/loaded correctly
   - Active model updates on provider change
   - OpenAI fields show saved values when returning to the provider

4. **API Communication**
   - Configure URL, API key, and model name
   - Trigger analysis from Request/Response tabs
   - Verify streaming response works
   - Verify fallback to non-streaming if needed
   - Error messages display correctly for invalid configuration

### Test Endpoints

- **z.ai GLM**: Use custom URL and model name
- **OpenAI**: Use official API endpoint
- **Groq**: Use groq API endpoint
- **Any OpenAI-compatible API**: Should work with standard format

## Backward Compatibility

- Existing OpenRouter and Ollama configurations are preserved
- New settings default to empty/not enabled
- No breaking changes to existing functionality

## Summary by Sourcery

Add an OpenAI-compatible provider option alongside OpenRouter and Ollama, with dedicated configuration, persistence, and request handling that supports streaming and non-streaming responses and reasoning-capable models.

New Features:
- Introduce an OpenAI-compatible API provider selectable via a new radio button in the configuration UI.
- Add configurable OpenAI-compatible settings for API URL, API key, and model name with visibility toggles and placeholders.
- Implement an OpenAI-compatible API handler using the /chat/completions endpoint with streaming and non-streaming fallback, including special handling for reasoning models and content fields.

Enhancements:
- Extend provider selection, model management, and configuration persistence to track separate models and settings for OpenRouter, Ollama, and OpenAI-compatible providers.
- Increase default max_tokens limits and adjust payload handling to avoid truncated responses for both OpenRouter and OpenAI-compatible requests.
- Enhance settings reset and config panel update logic to correctly preserve the active provider, reset fields, and keep UI state (e.g., masked/visible secrets) in sync.